### PR TITLE
use equivalent syntax to native pipe operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,16 +25,16 @@ A result tuple is a two-tuple tagged either as a success(`:ok`) or a failure(`:e
 
 ### '~>>' Macro
 
-This macro allows pipelining results through a pipeline of anonymous functions.
+This macro allows pipelining result tuples through a pipeline of functions.
 
 ```elixir
 import OK, only: :macros
 
 def get_employee_data(file, name) do
   {:ok, file}
-  ~>> &File.read/1
-  ~>> &Poison.decode/1
-  ~>> &Dict.fetch(&1, name)
+  ~>> File.read
+  ~>> Poison.decode
+  ~>> Dict.fetch(name)
 end
 
 def handle_user_data({:ok, data}), do: IO.puts("Contact at #{data["email"]}")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OK Elixir
 
-**Effecient error handling in elixir pipelines. See [Handling Errors in Elixir](http://insights.workshop14.io/2015/10/18/handling-errors-in-elixir-no-one-say-monad.html) for a more detailed explination**
+**Efficient error handling in elixir pipelines. See [Handling Errors in Elixir](http://insights.workshop14.io/2015/10/18/handling-errors-in-elixir-no-one-say-monad.html) for a more detailed explanation**
 
 [Documentation for OK is available on hexdoc](https://hexdocs.pm/ok)
 
@@ -11,13 +11,15 @@
   1. Add ok to your list of dependencies in `mix.exs`:
 
         def deps do
-          [{:ok, "~> 0.0.1"}]
+          [{:ok, "~> 0.2.0"}]
         end
 
 ## Usage
 
-The OK module works with the native error handling in Erlang/Elixir, that is a result tuple.
+The erlang convention for functions that can fail is to return a result tuple
 A result tuple is a two-tuple tagged either as a success(`:ok`) or a failure(`:error`).
+
+The OK module works with result tuples by treating them as a result monad.
 
 ```elixir
 {:ok, value} | {:error, reason}
@@ -26,6 +28,7 @@ A result tuple is a two-tuple tagged either as a success(`:ok`) or a failure(`:e
 ### '~>>' Macro
 
 This macro allows pipelining result tuples through a pipeline of functions.
+The `~>>` macro is the is equivalent to bind/flat_map in other languages.
 
 ```elixir
 import OK, only: :macros

--- a/lib/ok.ex
+++ b/lib/ok.ex
@@ -78,6 +78,10 @@ defmodule OK do
       iex> {:error, :previous_bad} ~>> double()
       {:error, :previous_bad}
 
+      # x is {:ok, 7} defined in `OKTest`.
+      iex> x ~>> double()
+      {:ok, 14}
+
   The result pipe is most useful when executing a series of operations that may fail.
 
       iex> {:ok, 6} ~>> safe_div(3) ~>> double
@@ -114,6 +118,11 @@ defmodule OK do
   Given an anonymous function the following syntax needs to be used.
 
       iex> {:ok, 3} ~>> (fn (x) -> {:ok, x + 1} end).()
+      {:ok, 4}
+
+      # decrement returns an anonymous function.
+      # weird I know but was needed as a test case
+      iex> {:ok, 6} ~>> decrement.(2)
       {:ok, 4}
   """
   defmacro lhs ~>> rhs do

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule OK.Mixfile do
 
   def project do
     [app: :ok,
-     version: "0.2.0-rc.1",
+     version: "0.2.0",
      elixir: "~> 1.1",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
@@ -25,7 +25,7 @@ defmodule OK.Mixfile do
 
   defp description do
     """
-    Effecient error handling in elixir pipelines.
+    Efficient error handling in elixir pipelines.
     """
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule OK.Mixfile do
 
   def project do
     [app: :ok,
-     version: "0.1.4",
+     version: "0.2.0-rc.1",
      elixir: "~> 1.1",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,2 @@
+%{"earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.14.2", "c89d60db464e8a0849a35dbcd6eed71f2b076c339d0b05b3bb5c90d6bab31e4f", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]}}

--- a/test/ok_test.exs
+++ b/test/ok_test.exs
@@ -36,59 +36,17 @@ defmodule OKTest do
     end
   end
 
-  test "wrapping a value as a success" do
-    assert {:ok, :any_value} = OK.success(:any_value)
-  end
-
-  test "wrapping a reason as a failure" do
-    assert {:error, :some_reason} = OK.failure(:some_reason)
-  end
-
-  # test "macro passes success value to function" do
-  #   report_func = fn (arg) -> send(self, arg) end
-  #
-  #   {:ok, :test_value} ~>> report_func
-  #   assert_receive :test_value
-  # end
-  #
-  # test "macro returns replied value" do
-  #   reply_func = fn (_arg) -> {:ok, :reply_ok} end
-  #
-  #   result = {:ok, :test_value} ~>> reply_func
-  #   assert {:ok, :reply_ok} == result
-  # end
-  #
-  # test "macro does not execute function for failure tuple" do
-  #   fail_func = fn (_arg) -> flunk("Should not be called") end
-  #
-  #   {:error, :error_reason} ~>> fail_func
-  # end
-  #
-  # test "macro returns original error" do
-  #   error_func = fn (_arg) -> {:error, :new_error} end
-  #
-  #   result = {:error, :original_error} ~>> error_func
-  #   assert {:error, :original_error} == result
-  # end
-  #
-  # test "macro must only take a function in success case" do
-  #   assert_raise FunctionClauseError, fn ->
-  #     {:ok, :test_value} ~>> :no_func
-  #   end
-  # end
-
-  test "scratch pad" do
-    x = {:ok, 7}
-    assert {:ok, 14} == x ~>> double
-    decrement = fn (a, b) -> {:ok, a - b} end
-    assert {:ok, 4} == {:ok, 6} ~>> decrement.(2)
-    assert {:ok, 10} == {:ok, 5} ~>> (&double/1).()
-    # assert {:ok, 16} == {:ok, 5} ~>> &add(3, &1)
-
-  end
-
+  # These are all used in doc tests
   def double(a) do
     {:ok, 2 * a}
+  end
+
+  def x do
+    {:ok, 7}
+  end
+
+  def decrement() do
+    fn (a, b) -> {:ok, a - b} end
   end
 
   def safe_div(_, 0) do

--- a/test/ok_test.exs
+++ b/test/ok_test.exs
@@ -44,36 +44,57 @@ defmodule OKTest do
     assert {:error, :some_reason} = OK.failure(:some_reason)
   end
 
-  test "macro passes success value to function" do
-    report_func = fn (arg) -> send(self, arg) end
+  # test "macro passes success value to function" do
+  #   report_func = fn (arg) -> send(self, arg) end
+  #
+  #   {:ok, :test_value} ~>> report_func
+  #   assert_receive :test_value
+  # end
+  #
+  # test "macro returns replied value" do
+  #   reply_func = fn (_arg) -> {:ok, :reply_ok} end
+  #
+  #   result = {:ok, :test_value} ~>> reply_func
+  #   assert {:ok, :reply_ok} == result
+  # end
+  #
+  # test "macro does not execute function for failure tuple" do
+  #   fail_func = fn (_arg) -> flunk("Should not be called") end
+  #
+  #   {:error, :error_reason} ~>> fail_func
+  # end
+  #
+  # test "macro returns original error" do
+  #   error_func = fn (_arg) -> {:error, :new_error} end
+  #
+  #   result = {:error, :original_error} ~>> error_func
+  #   assert {:error, :original_error} == result
+  # end
+  #
+  # test "macro must only take a function in success case" do
+  #   assert_raise FunctionClauseError, fn ->
+  #     {:ok, :test_value} ~>> :no_func
+  #   end
+  # end
 
-    {:ok, :test_value} ~>> report_func
-    assert_receive :test_value
+  test "scratch pad" do
+    x = {:ok, 7}
+    assert {:ok, 14} == x ~>> double
+    decrement = fn (a, b) -> {:ok, a - b} end
+    assert {:ok, 4} == {:ok, 6} ~>> decrement.(2)
+    assert {:ok, 10} == {:ok, 5} ~>> (&double/1).()
+    # assert {:ok, 16} == {:ok, 5} ~>> &add(3, &1)
+
   end
 
-  test "macro returns replied value" do
-    reply_func = fn (_arg) -> {:ok, :reply_ok} end
-
-    result = {:ok, :test_value} ~>> reply_func
-    assert {:ok, :reply_ok} == result
+  def double(a) do
+    {:ok, 2 * a}
   end
 
-  test "macro does not execute function for failure tuple" do
-    fail_func = fn (_arg) -> flunk("Should not be called") end
-
-    {:error, :error_reason} ~>> fail_func
+  def safe_div(_, 0) do
+    {:error, :zero_division}
   end
-
-  test "macro returns original error" do
-    error_func = fn (_arg) -> {:error, :new_error} end
-
-    result = {:error, :original_error} ~>> error_func
-    assert {:error, :original_error} == result
-  end
-
-  test "macro must only take a function in success case" do
-    assert_raise FunctionClauseError, fn ->
-      {:ok, :test_value} ~>> :no_func
-    end
+  def safe_div(a, b) do
+    {:ok, a / b}
   end
 end


### PR DESCRIPTION
Looking at the changes in documentation is probably the easiest way to see what is proposed here. In short the pipeline no longer accepts anonymous functions but uses the same syntax as the native pipe operator. The following is now possible.

A release candidate is also available to be downloaded from [hex](https://hex.pm/packages/ok)

```elixir
import OK, only: :macros

def get_employee_data(file, name) do
  {:ok, file}
  ~>> File.read
  ~>> Poison.decode
  ~>> Dict.fetch(name)
end

def handle_user_data({:ok, data}), do: IO.puts("Contact at #{data["email"]}")
def handle_user_data({:error, :enoent}), do: IO.puts("File not found")
def handle_user_data({:error, {:invalid, _}}), do: IO.puts("Invalid JSON")
def handle_user_data({:error, :key_not_found}), do: IO.puts("Could not find employee")

get_employee_data("my_company/employees.json")
|> handle_user_data
```

Questions remaining are

- Should the `~>>` macro try and accept anonymous functions too.
- What invalid cases should be caught at compile time.