### PR TITLE
Issue 13 Improve Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Elegant handling of idiomatic Erlang conventions of `:ok`/`:error` tuples in Elixir. This includes more concise and readable `with` statement syntax, a tagged-enabled pipeline operator, and semantic pattern matching.**
 
-* [Handling Errors in Elixir](http://insights.workshop14.io/2015/10/18/handling-errors-in-elixir-no-one-say-monad.html)
+- [Handling Errors in Elixir](http://insights.workshop14.io/2015/10/18/handling-errors-in-elixir-no-one-say-monad.html)
 
 ## Installation
 
@@ -30,14 +30,14 @@ The following sections cover how these result tuples are used in `OK.with`, `~>>
 
 `OK.with` allows for more concise and ultimately more readable code than the native `with` construct. It does this by leveraging result monads for both the happy and non-happy paths. By extracting the actual function return values from the result tuples, `OK.with` reduces noise which improves readability and recovers precious horizontal code real estate. This also encourages writing idiomatic Elixir functions which return `:ok`/`:error` tuples.
 
-* [Elegant error handling with result monads, alternative to elixir `with` special form](https://elixirforum.com/t/elegant-error-handling-with-result-monads-alternative-to-elixir-with-special-form/3264/1)
-* [Discussion on :ok/:error](https://elixirforum.com/t/usage-of-ok-result-error-vs-some-result-none/3253)
+- [Elegant error handling with result monads, alternative to elixir `with` special form](https://elixirforum.com/t/elegant-error-handling-with-result-monads-alternative-to-elixir-with-special-form/3264/1)
+- [Discussion on :ok/:error](https://elixirforum.com/t/usage-of-ok-result-error-vs-some-result-none/3253)
 
 #### Basic Usage
 
-* Use the `<-` operator to match & extract a value for an `:ok` tuple.
-* Use the `=` operator as you normally would for pattern matching an untagged result.
-* The last line should either be a function that returns the tuple, or the literal tuple itself.
+- Use the `<-` operator to match & extract a value for an `:ok` tuple.
+- Use the `=` operator as you normally would for pattern matching an untagged result.
+- The last line should either be a function that returns the tuple, or the literal tuple itself.
 
 _NB: Statements are **not** delimited by commas as with the native Elixir `with` construct._
 
@@ -135,13 +135,13 @@ end
 
 ## Additional External Links and Resources
 
-* Elixir Forum
-  * [OK v1 library](https://elixirforum.com/t/ok-elegant-error-handling-for-elixir-pipelines-version-1-0-released/1932/)
-* [Railway programming](http://www.zohaib.me/railway-programming-pattern-in-elixir/)
-* Similar Libraries
-  * [exceptional](https://github.com/expede/exceptional)
-  * [elixir-monad](https://github.com/nickmeharry/elixir-monad)
-  * [happy_with](https://github.com/vic/happy_with)
-  * [monad](https://github.com/rmies/monad)
-  * [ok_jose](https://github.com/vic/ok_jose)
-  * [towel](https://github.com/knrz/towel)
+- Elixir Forum
+  - [OK v1 library](https://elixirforum.com/t/ok-elegant-error-handling-for-elixir-pipelines-version-1-0-released/1932/)
+- [Railway programming](http://www.zohaib.me/railway-programming-pattern-in-elixir/)
+- Similar Libraries
+  - [exceptional](https://github.com/expede/exceptional)
+  - [elixir-monad](https://github.com/nickmeharry/elixir-monad)
+  - [happy_with](https://github.com/vic/happy_with)
+  - [monad](https://github.com/rmies/monad)
+  - [ok_jose](https://github.com/vic/ok_jose)
+  - [towel](https://github.com/knrz/towel)

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ _NB: Statements are **not** delimited by commas as with the native Elixir `with`
 require OK
 
 OK.with do
-  user <- fetch_user(1)        # <- operator means func returns {:ok, user}
-  cart <- fetch_cart(1)        # <- again, {:ok, cart}
+  user <- fetch_user(1)        # `<-` operator means func returns {:ok, user}
+  cart <- fetch_cart(1)        # `<-` again, {:ok, cart}
   order = checkout(cart, user) # `=` allows pattern matching on non-tagged funcs
   save_order(order)            # Returns a tuple.
 end

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 **Elegant handling of idiomatic Erlang conventions of `:ok`/`:error` tuples in Elixir. This includes more concise and readable `with` statement syntax, a tagged-enabled pipeline operator, and semantic pattern matching.**
 
+* [Handling Errors in Elixir](http://insights.workshop14.io/2015/10/18/handling-errors-in-elixir-no-one-say-monad.html)
+
 ## Installation
 
 [Available in Hex](https://hex.pm/packages/ok), the package can be installed as:
@@ -25,6 +27,11 @@ The OK module works with result tuples by treating them as a result monad.
 The following sections cover how these result tuples are used in `OK.with`, `~>>` (OK pipeline operator), and semantic pattern matching.
 
 ### `OK.with`
+
+`OK.with` allows for more concise and ultimately more readable code than the native `with` construct. It does this by leveraging result monads for both the happy and non-happy paths. By extracting the actual function return values from the result tuples, `OK.with` reduces noise which improves readability and recovers precious horizontal code real estate. This also encourages writing idiomatic Elixir functions which return `:ok`/`:error` tuples.
+
+* [Elegant error handling with result monads, alternative to elixir `with` special form](https://elixirforum.com/t/elegant-error-handling-with-result-monads-alternative-to-elixir-with-special-form/3264/1)
+* [Discussion on :ok/:error](https://elixirforum.com/t/usage-of-ok-result-error-vs-some-result-none/3253)
 
 #### Basic Usage
 
@@ -78,7 +85,7 @@ end
 
 ####  Error Matching
 
-`OK.with` accepts also an else block which can be used for handling error results. Note that you pattern match on the _untagged_ error value, often denoted as `reason` in e.g. `{:error, reason}`.
+`OK.with` also accepts an else block which can be used for handling error results. Note that you pattern match on the _untagged_ error value, often denoted as `reason` in e.g. `{:error, reason}`.
 
 ```elixir
 OK.with do
@@ -126,13 +133,9 @@ case fetch_user(id) do
 end
 ```
 
-## External Links and Resources
+## Additional External Links and Resources
 
-* [OK on Hex Docs](https://hex.pm/packages/ok)
-* [Handling Errors in Elixir](http://insights.workshop14.io/2015/10/18/handling-errors-in-elixir-no-one-say-monad.html)
 * Elixir Forum
-  * [Elegant error handling with result monads, alternative to elixir `with` special form](https://elixirforum.com/t/elegant-error-handling-with-result-monads-alternative-to-elixir-with-special-form/3264/1)
-  * [Discussion on :ok/:error](https://elixirforum.com/t/usage-of-ok-result-error-vs-some-result-none/3253)
   * [OK v1 library](https://elixirforum.com/t/ok-elegant-error-handling-for-elixir-pipelines-version-1-0-released/1932/)
 * [Railway programming](http://www.zohaib.me/railway-programming-pattern-in-elixir/)
 * Similar Libraries

--- a/README.md
+++ b/README.md
@@ -90,8 +90,7 @@ else
 end
 ```
 
-*Unlike native with any unmatched error case does not throw an error and will just be passed as the return value*
-
+*Unlike Elixir's native `with` construct, any unmatched error case does not throw an error and will just be passed as the return value*
 
 ### Result Pipeline Operator `~>>`
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The OK module works with result tuples by treating them as a result monad.
 {:ok, value} | {:error, reason}
 ```
 
-The following sections cover this is used in `OK.with`, `~>>`, and semantic pattern matching.
+The following sections cover how these result tuples are used in `OK.with`, `~>>` (OK pipeline operator), and semantic pattern matching.
 
 ### `OK.with`
 

--- a/lib/ok.ex
+++ b/lib/ok.ex
@@ -150,32 +150,52 @@ defmodule OK do
   end
 
   @doc """
-  Combine multiple functions that may return an error.
+  Composes multiple functions similar to Elixir's native `with` construct.
+  
+  `OK.with/1` enables more terse and readable expressions however, eliminating
+  noise and regaining precious horizontal real estate in the process. It does 
+  this by extracting result tuples when using the `<-` operator.
+  
+  For example, in native Elixir, you could write a `with` statement as follows:
+  
+  ```elixir
+  with {:ok, a} <- save_div(8,2),
+       {:ok, b} <- save_div(a,2),
+       do: {:ok, b}
+  ```
+  
+  With `OK.with/1`, this can be rewritten as follows:
+  ```elixir
+  OK.with do
+    a <- save_div(8,2)
+    b <- save_div(a,2)
+    {:ok, b}
+  end
+  ```
 
-  `OK.with/1 is a strict version of the native elixir with special form.
-  It is stricter because it will only handle result tuples.
-  This however allows for more terse expressions.
-
-  When combining funcations that may fail the result pipe operator is inflexible in several areas.
+  ### Compared to `~>>`
+  
+  When combining functions that may fail, the OK pipe operator is inflexible in
+  a couple areas: 
   - values can only be passed to the first argument of a function.
   - values can only be passed to the next function.
 
-  These limitations can be overcome by `OK.with/1`
+  These limitations can be overcome by `OK.with/1`.
 
   ## Examples
 
       iex> OK.with do
-      iex>   a <- safe_div(8, 2)
-      iex>   b <- safe_div(a, 2)
-      iex>   {:ok, a + b}
-      iex> end
+      ...>   a <- safe_div(8, 2)
+      ...>   b <- safe_div(a, 2)
+      ...>   {:ok, a + b}
+      ...> end
       {:ok, 6.0}
 
       iex> OK.with do
-      iex>   a <- safe_div(8, 2)
-      iex>   b <- safe_div(a, 0)
-      iex>   {:ok, a + b}
-      iex> end
+      ...>   a <- safe_div(8, 2)
+      ...>   b <- safe_div(a, 0)
+      ...>   {:ok, a + b}
+      ...> end
       {:error, :zero_division}
   """
   defmacro with(do: {:__block__, _env, lines}) do

--- a/lib/ok.ex
+++ b/lib/ok.ex
@@ -159,16 +159,16 @@ defmodule OK do
   For example, in native Elixir, you could write a `with` statement as follows:
   
   ```elixir
-  with {:ok, a} <- save_div(8,2),
-       {:ok, b} <- save_div(a,2),
+  with {:ok, a} <- safe_div(8,2),
+       {:ok, b} <- safe_div(a,2),
        do: {:ok, b}
   ```
   
   With `OK.with/1`, this can be rewritten as follows:
   ```elixir
   OK.with do
-    a <- save_div(8,2)
-    b <- save_div(a,2)
+    a <- safe_div(8,2)
+    b <- safe_div(a,2)
     {:ok, b}
   end
   ```


### PR DESCRIPTION
I've just worked a little on the README only. I haven't touched the module docs aspect, but I wanted to go ahead and get the PR started - so I wouldn't merge it yet, even if it's passable.

_Definitely_ be sure that I got the usage of `OK.with` down because I haven't actually _used_ it yet!!

Also, I am unsure of the statement:

> *Unlike native with any unmatched error case does not throw an error and will just be passed as the return value*

Has this been tested? I thought when I was tinkering that this was not the case. Perhaps I am thinking of pre-1.5.0 release though.

I removed the `handle_user_data` lines in the pipeline section, because I thought they were superfluous and confusing (I know I personally was confused when reading the README at that point in time). 