### PR TITLE
OK.with warnings, doctests, errata

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ OK.with do
   cart <- fetch_cart(1)        # `<-` again, {:ok, cart}
   order = checkout(cart, user) # `=` allows pattern matching on non-tagged funcs
   save_order(order)            # Returns an ok/error tuple
+end
 ```
 
 The cart example above is equivalent to the following nested `case` statements

--- a/lib/ok.ex
+++ b/lib/ok.ex
@@ -231,7 +231,6 @@ defmodule OK do
   end
 
   defp nest([{:<-, _, [left, right]} | []]) do
-    # last line of with block is a <- extraction
     quote do
       case unquote(right) do
         result = {:ok, unquote(left)} ->
@@ -251,21 +250,7 @@ defmodule OK do
       end
     end
   end
-  defp nest([{:ok, _} = normal | []]) do
-    # last line of the with block is an ok literal
-    quote do
-      unquote(normal)
-    end
-  end
-  
-  defp nest([{{:., _, [{:__aliases__, _, [:OK]}, :success]}, _, _} = normal | []]) do
-    # last line of the with block is an OK.success macro line
-    quote do
-      unquote(normal)
-    end
-  end
   defp nest([normal | []]) do
-    # last line of the with block is a func
     quote do
       case unquote(normal) do
         {:ok, value} ->

--- a/lib/ok.ex
+++ b/lib/ok.ex
@@ -161,7 +161,21 @@ defmodule OK do
       iex> OK.with do
       ...>   a <- safe_div(8, 2)
       ...>   b <- safe_div(a, 2)
+      ...>   OK.success a + b
+      ...> end
+      {:ok, 6.0}
+
+      iex> OK.with do
+      ...>   a <- safe_div(8, 2)
+      ...>   b <- safe_div(a, 2)
       ...>   {:ok, a + b}
+      ...> end
+      {:ok, 6.0}
+
+      iex> OK.with do
+      ...>   a <- safe_div(8, 2)
+      ...>   b = 2.0
+      ...>   OK.success a + b
       ...> end
       {:ok, 6.0}
 
@@ -172,11 +186,14 @@ defmodule OK do
       ...> end
       {:error, :zero_division}
 
-      # Equivalent native with version
-      iex> with {:ok, a} <- safe_div(8,2),
-      ...>      {:ok, b} <- safe_div(a,2),
-      ...>      do: {:ok, b}
-      {:ok, 6.0}
+      iex> OK.with do
+      ...>   a <- safe_div(8, 2)
+      ...>   b <- safe_div(a, 0)
+      ...>   {:ok, a + b}
+      ...> else
+      ...>   :zero_division -> OK.failure "You cannot divide by 0."
+      ...> end
+      {:error, "You cannot divide by 0."}
   """
   defmacro with(do: {:__block__, _env, lines}) do
     nest(lines)
@@ -205,13 +222,16 @@ defmodule OK do
 
   require Logger
 
-  @doc false
+  @doc """
+  DEPRECATED: `OK.try` has been replaced with `OK.with`
+  """
   defmacro try(do: {:__block__, _env, lines}) do
-    Logger.warn("DEPRECIATED: `OK.try` has been replaced with `OK.with`")
+    Logger.warn("DEPRECATED: `OK.try` has been replaced with `OK.with`")
     nest(lines)
   end
 
   defp nest([{:<-, _, [left, right]} | []]) do
+    # last line of with block is a <- extraction
     quote do
       case unquote(right) do
         result = {:ok, unquote(left)} ->
@@ -231,7 +251,21 @@ defmodule OK do
       end
     end
   end
+  defp nest([{:ok, _} = normal | []]) do
+    # last line of the with block is an ok literal
+    quote do
+      unquote(normal)
+    end
+  end
+  
+  defp nest([{{:., _, [{:__aliases__, _, [:OK]}, :success]}, _, _} = normal | []]) do
+    # last line of the with block is an OK.success macro line
+    quote do
+      unquote(normal)
+    end
+  end
   defp nest([normal | []]) do
+    # last line of the with block is a func
     quote do
       case unquote(normal) do
         {:ok, value} ->

--- a/test/ok_test.exs
+++ b/test/ok_test.exs
@@ -71,7 +71,16 @@ defmodule OKTest do
     assert result == {:ok, 2}
   end
 
-  test "primitives as final operation" do
+  test "primitives as final operation - ok literal" do
+    result = OK.with do
+      a <- safe_div(8, 2)
+      b <- safe_div(a, 2)
+      {:ok, b}
+    end
+    assert result == {:ok, 2}
+  end
+
+  test "primitives as final operation - ok literal func" do
     result = OK.with do
       a <- safe_div(8, 2)
       b <- safe_div(a, 2)
@@ -80,13 +89,42 @@ defmodule OKTest do
     assert result == {:ok, 6}
   end
 
-  test "function as final operation" do
+  test "primitives as final operation - OK.success literal" do
     result = OK.with do
       a <- safe_div(8, 2)
       b <- safe_div(a, 2)
-      OK.failure(a + b)
+      # {:ok, a + b}
+      # OK.success a + b
+      OK.success b
     end
-    assert result == {:error, 6}
+    assert result == {:ok, 2}
+  end
+
+  test "primitives as final operation - OK.success func" do
+    result = OK.with do
+      a <- safe_div(8, 2)
+      b <- safe_div(a, 2)
+      OK.success a + b
+    end
+    assert result == {:ok, 6}
+  end
+
+  test "function as final operation - pass" do
+    result = OK.with do
+      a <- safe_div(8, 2)
+      b <- safe_div(a, 2)
+      pass_func(b)
+    end
+    assert result == {:ok, 2.0}
+  end
+
+  test "function as final operation - fail" do
+    result = OK.with do
+      a <- safe_div(8, 2)
+      b <- safe_div(a, 2)
+      fail_func(b)
+    end
+    assert result == {:error, 2.0}
   end
 
   test "will fail to match if the return value is not a result" do
@@ -171,5 +209,13 @@ defmodule OKTest do
   end
   def safe_div(a, b) do
     {:ok, a / b}
+  end
+  
+  def pass_func(x) do
+    {:ok, x}
+  end
+  
+  def fail_func(x) do
+    {:error, x}
   end
 end


### PR DESCRIPTION
* OK.with warnings
  * See issue CrowdHailer/OK#18.
* doctests
  * I added a couple doctests to the `with` macro.
  * I also added some unit tests as well.
    * Note, I changed the one unit test to use `fail_func` instead of `OK.failure` because the failure is a macro and was causing a compile-time warning instead of testing passing through error functionality.
* errata
  * "deprecated" spelling. Added this as the doc instead of `@doc false`.