### PR TITLE
Revert "dont add special case for warning"

### DIFF
--- a/lib/ok.ex
+++ b/lib/ok.ex
@@ -241,23 +241,13 @@ defmodule OK do
       end
     end
   end
-  defp nest([{:<-, _, [left, right]} | rest]) do
-    quote do
-      case unquote(right) do
-        {:ok, unquote(left)} ->
-          unquote(nest(rest))
-        result = {:error, _} ->
-          result
-      end
-    end
-  end
   defp nest([{:ok, _} = normal | []]) do
     # last line of the with block is an ok literal
     quote do
       unquote(normal)
     end
   end
-  
+
   defp nest([{{:., _, [{:__aliases__, _, [:OK]}, :success]}, _, _} = normal | []]) do
     # last line of the with block is an OK.success macro line
     quote do
@@ -265,13 +255,23 @@ defmodule OK do
     end
   end
   defp nest([normal | []]) do
-    # last line of the with block is a func
+    # last line of the with block is a function
     quote do
       case unquote(normal) do
         {:ok, value} ->
           {:ok, value}
         {:error, reason} ->
           {:error, reason}
+      end
+    end
+  end
+  defp nest([{:<-, _, [left, right]} | rest]) do
+    quote do
+      case unquote(right) do
+        {:ok, unquote(left)} ->
+          unquote(nest(rest))
+        result = {:error, _} ->
+          result
       end
     end
   end

--- a/lib/ok.ex
+++ b/lib/ok.ex
@@ -231,6 +231,7 @@ defmodule OK do
   end
 
   defp nest([{:<-, _, [left, right]} | []]) do
+    # last line of with block is a <- extraction
     quote do
       case unquote(right) do
         result = {:ok, unquote(left)} ->
@@ -250,7 +251,21 @@ defmodule OK do
       end
     end
   end
+  defp nest([{:ok, _} = normal | []]) do
+    # last line of the with block is an ok literal
+    quote do
+      unquote(normal)
+    end
+  end
+  
+  defp nest([{{:., _, [{:__aliases__, _, [:OK]}, :success]}, _, _} = normal | []]) do
+    # last line of the with block is an OK.success macro line
+    quote do
+      unquote(normal)
+    end
+  end
   defp nest([normal | []]) do
+    # last line of the with block is a func
     quote do
       case unquote(normal) do
         {:ok, value} ->

--- a/test/ok_test.exs
+++ b/test/ok_test.exs
@@ -131,7 +131,7 @@ defmodule OKTest do
     assert_raise CaseClauseError, fn() ->
       OK.with do
         a <- safe_div(8, 2)
-        {:x, a}
+        (fn() -> {:x, a} end).()
       end
     end
   end
@@ -210,11 +210,11 @@ defmodule OKTest do
   def safe_div(a, b) do
     {:ok, a / b}
   end
-  
+
   def pass_func(x) do
     {:ok, x}
   end
-  
+
   def fail_func(x) do
     {:error, x}
   end


### PR DESCRIPTION
This reverts commit e5eb3f254ef3b2ca394920f654900c1040ef53a0.

This was the changes I look out of pr #19 
I think solving this issue #18 is a good goal but I would like to take the time for a more complete solution and this PR is to keep those efforts in one place