### PR TITLE
Issue 24 catchall warning in OK.with else block

### DIFF
--- a/lib/ok.ex
+++ b/lib/ok.ex
@@ -199,10 +199,16 @@ defmodule OK do
     nest(lines)
   end
   defmacro with(do: {:__block__, _, normal}, else: exceptional) do
-    exceptional_clauses = exceptional ++ (quote do
-      reason ->
-        {:error, reason}
-    end)
+    exceptional_clauses =
+      if Enum.any?(exceptional, &exception_is_catchall?/1) do
+        exceptional
+      else
+        # Add a catchall exception block to pass through unmatched errors.
+        exceptional ++ (quote do
+                          reason -> {:error, reason}
+                        end)
+      end
+
     quote do
       unquote(nest(normal))
       |> case do
@@ -217,6 +223,23 @@ defmodule OK do
               result
           end
       end
+    end
+  end
+  
+  # Normal exception blocks
+  #   {:->, [line: 147], [["string_reason"], {:error, "string fail"}]}
+  #   {:->, [line: 148], [[:atom_reason], {:error, "atom fail"}]}
+  # Catchall exception block:
+  #   {:->, [line: 149], [[{:_reason, [line: 149], nil}], {:error, "catchall fail"}]}
+  defp exception_is_catchall?(exception_block) do
+    # 
+    {_,_,exc_contents} = exception_block
+    exc_match = exc_contents |> Enum.at(0) |> Enum.at(0)
+    case exc_match do
+      {_,_, nil} -> 
+        true
+      _ -> 
+        false
     end
   end
 

--- a/test/ok_test.exs
+++ b/test/ok_test.exs
@@ -11,6 +11,17 @@ defmodule OKTest do
     assert result == {:ok, 2}
   end
 
+  test "correct an error" do
+    result = OK.with do
+      a <- safe_div(8, 2)
+      _ <- safe_div(a, 0)
+    else
+      :zero_division ->
+        success(:inf)
+    end
+    assert result == {:ok, :inf}
+  end
+
   test "modify an error" do
     result = OK.with do
       a <- safe_div(8, 2)

--- a/test/ok_test.exs
+++ b/test/ok_test.exs
@@ -11,17 +11,6 @@ defmodule OKTest do
     assert result == {:ok, 2}
   end
 
-  test "correct an error" do
-    result = OK.with do
-      a <- safe_div(8, 2)
-      _ <- safe_div(a, 0)
-    else
-      :zero_division ->
-        success(:inf)
-    end
-    assert result == {:ok, :inf}
-  end
-
   test "modify an error" do
     result = OK.with do
       a <- safe_div(8, 2)
@@ -35,7 +24,7 @@ defmodule OKTest do
     assert result == {:error, :inf}
   end
 
-  test "pass through an error" do
+  test "pass through an error with else block present" do
     result = OK.with do
       a <- safe_div(8, 2)
       _ <- safe_div(a, 0)

--- a/test/ok_test.exs
+++ b/test/ok_test.exs
@@ -147,6 +147,43 @@ defmodule OKTest do
       end
     end
   end
+  
+  test "override catchall else block - no warning" do
+    # a catchall in an else block should not create a compiler warning.
+    
+    # else block with raw error tuples
+    OK.with do
+      a <- safe_div(8, 2)
+      b <- safe_div(a, 2)
+      OK.success a + b
+    else
+      "string_reason" -> {:error, "string fail"}
+      :atom_reason -> {:error, "atom fail"}
+      _reason -> {:error, "catchall fail"}
+    end
+
+    # else block with OK.failure macros
+    OK.with do
+      a <- safe_div(8, 2)
+      b <- safe_div(a, 2)
+      OK.success a + b
+    else
+      "string_reason" -> OK.failure "string fail"
+      :atom_reason -> OK.failure "atom fail"
+      _reason -> OK.failure "catchall fail"
+    end
+    
+    # else block with funcs
+    OK.with do
+      a <- safe_div(8, 2)
+      b <- safe_div(a, 2)
+      OK.success a + b
+    else
+      "string_reason" -> fail_func("string fail")
+      :atom_reason -> fail_func("atom fail")
+      _reason -> fail_func("catchall fail")
+    end
+  end
 
   test "matching on a success case" do
     success(value) = {:ok, :value}


### PR DESCRIPTION
* Added a conditional check, and associated function, when an `else`
  block is present.
  * Added a test to ensure that the compiler warning is not produced.

Closes #24