### PR TITLE
raise BadResultError not CaseClauseError

### DIFF
--- a/lib/ok.ex
+++ b/lib/ok.ex
@@ -138,6 +138,26 @@ defmodule OK do
     end
   end
 
+  defmodule BadResultError do
+    defexception [:actual, :code]
+
+    def message(%{actual: actual, code: code}) do
+      """
+      final value from block was invalid, a result tuple was expected.
+
+          Code
+            #{code}
+
+          Expected output
+            {:ok, value} | {:error, reason}
+
+          Actual output
+            #{actual |> inspect}
+      """
+    end
+  end
+
+
   @doc """
   Composes multiple functions similar to Elixir's native `with` construct.
 
@@ -251,6 +271,8 @@ defmodule OK do
       case unquote(return) do
         result = {tag, _} when tag in [:ok, :error] ->
           result
+        wrong ->
+          raise %BadResultError{actual: wrong, code: unquote(Macro.to_string(List.last(lines)))}
       end
     end
   end

--- a/test/ok_test.exs
+++ b/test/ok_test.exs
@@ -125,15 +125,6 @@ defmodule OKTest do
     assert result == {:error, 2.0}
   end
 
-  test "will fail to match if the return value is not a result" do
-    assert_raise CaseClauseError, fn() ->
-      OK.with do
-        a <- safe_div(8, 2)
-        (fn() -> {:x, a} end).()
-      end
-    end
-  end
-
   test "will fail to match if the return value of exceptional block is not a result" do
     assert_raise CaseClauseError, fn() ->
       OK.with do


### PR DESCRIPTION
Be more informative when the return value is not a result tuple.

here is an opportunity to educate users that the return value needs to be a result tuple, rather than issueing a cryptic case clause error.

This PR has a worked out how to raise this error for the main do block, but not for the else block.