### PR TITLE
OK.Kernel to add bind operator to any function

### DIFF
--- a/lib/ok.ex
+++ b/lib/ok.ex
@@ -277,9 +277,29 @@ defmodule OK do
     end
   end
 
+  defmacro def(signature, do: code) do
+    {:__block__, _env, lines} = wrap_code_block(code)
+    quote do
+      Kernel.def unquote(signature) do
+        unquote(bind_match(lines))
+      end
+    end
+  end
+  defmacro def(signature, do: code, else: exceptional) do
+    {:__block__, _env, lines} = wrap_code_block(code)
+    quote do
+      Kernel.def unquote(signature) do
+        unquote(bind_match(lines, exceptional))
+      end
+    end
+  end
+
   defp wrap_code_block(block = {:__block__, _env, _lines}), do: block
   defp wrap_code_block(expression = {_, env, _}) do
      {:__block__, env, [expression]}
+   end
+  defp wrap_code_block(primitive) do
+     {:__block__, [], [primitive]}
    end
 
   require Logger
@@ -311,20 +331,35 @@ defmodule OK do
     end
   end
 
-  defp bind_match([]) do
+  defp bind_match(code, exceptional \\ nil)
+  defp bind_match([], _exceptional) do
     quote do: nil
   end
-  defp bind_match([{:<-, env, [left, right]} | rest]) do
+  defp bind_match([{:<-, env, [left, right]} | rest], exceptional) do
     line = Keyword.get(env, :line)
     lhs_string = Macro.to_string(left)
     rhs_string = Macro.to_string(right)
     tmp = quote do: tmp
+    result = quote do: result
+    result_handler = if exceptional == nil do
+      result
+    else
+      # TODO link error line number to the bind that triggered it
+      [{:->, e, _} | _] = exceptional
+      l = Keyword.get(e, :line)
+      quote line: l - 1 do
+        {:error, reason} = unquote(result)
+        case reason do
+          unquote(exceptional)
+        end
+      end
+    end
     quote line: line do
       case unquote(tmp) = unquote(right) do
         {:ok, unquote(left)} ->
-          unquote(bind_match(rest) || tmp)
-        result = {:error, _} ->
-          result
+          unquote(bind_match(rest, exceptional) || tmp)
+        unquote(result) = {:error, _} ->
+          unquote(result_handler)
         return ->
           raise %BindError{
             return: return,
@@ -333,11 +368,11 @@ defmodule OK do
       end
     end
   end
-  defp bind_match([normal | rest]) do
+  defp bind_match([normal | rest], exceptional) do
     tmp = quote do: tmp
     quote do
       unquote(tmp) = unquote(normal)
-      unquote(bind_match(rest) || tmp)
+      unquote(bind_match(rest, exceptional) || tmp)
     end
   end
 end

--- a/lib/ok.ex
+++ b/lib/ok.ex
@@ -277,6 +277,7 @@ defmodule OK do
     end
   end
 
+  @doc false
   defmacro def(signature, do: code) do
     {:__block__, _env, lines} = wrap_code_block(code)
     quote do

--- a/lib/ok/kernel.ex
+++ b/lib/ok/kernel.ex
@@ -1,0 +1,8 @@
+defmodule OK.Kernel do
+  defmacro __using__(_opts) do
+    quote do
+      import Kernel, except: [def: 2]
+      import OK, only: [def: 2]
+    end
+  end
+end

--- a/lib/ok/kernel.ex
+++ b/lib/ok/kernel.ex
@@ -1,5 +1,38 @@
 defmodule OK.Kernel do
+  @moduledoc """
+  Add ok binding to all functions.
+
+  **NOTE** this is an experimental feature,
+  it will be removed or added permanently for 2.0 release
+
+  ## Example
+
+      defmodule MyApp do
+        use OK.Kernel
+
+        def checkout(user_id, cart_id) do
+          user <- fetch_user(user_id)        # `<-` will bind user when fetch_user returns {:ok, user}
+          cart <- fetch_cart(cart_id)        # `<-` will shortcut to else clause if returned {:error, reason}
+          order = checkout(cart, user) # `=` allows pattern matching on non-tagged funcs
+
+          order.invoice_id
+        else
+          :user_not_found ->
+            IO.puts("No user for user_id: \#{user_id}")
+            nil
+          :user_not_found ->
+            IO.puts("User has no cart")
+            nil
+        end
+
+      end
+
+  TODO move examples to `OK.def/2`
+  """
+
+  require Logger
   defmacro __using__(_opts) do
+    Logger.warn("Experimental: Use of `OK.Kernel` redefines function definition.")
     quote do
       import Kernel, except: [def: 2]
       import OK, only: [def: 2]

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule OK.Mixfile do
 
   def project do
     [app: :ok,
-     version: "1.6.2",
+     version: "1.7.0-rc.1",
      elixir: "~> 1.1",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,

--- a/test/ok/kernel_test.exs
+++ b/test/ok/kernel_test.exs
@@ -1,0 +1,36 @@
+defmodule OK.KernelTest do
+  use ExUnit.Case
+  defmodule Example do
+    use OK.Kernel
+
+    def alright(value), do: {:ok, value}
+
+    def maybe(:good), do: {:ok, :good}
+    def maybe(:bad), do: {:error, :bad}
+    def maybe(other), do: {:error, other}
+
+    def run(test) do
+      intermediate <- alright(test)
+      final <- maybe(intermediate)
+
+      final
+    else
+      :bad ->
+        :rescued
+    end
+  end
+
+  test "can return any value from function body" do
+    assert :good == Example.run(:good)
+  end
+
+  test "errors can be handled in an else clause" do
+    assert :rescued == Example.run(:bad)
+  end
+
+  test "unhandled exceptions will raise an error" do
+    assert_raise CaseClauseError, fn() ->
+      Example.run(:unhandled)
+    end
+  end
+end


### PR DESCRIPTION
Allows a user to do this

```elixir
  use OK.Kernel

  def run(input) do
    intermediate <- alright(input)
    final <- maybe(intermediate)

    final
  else
    :bad ->
      :rescued
  end
```

alright/maybe are functions that return an ok/error tuple. binding the value to intermediate/final from the inside of an ok tuple.

Note, different to with as it does not enforce any shape of return value