### PR TITLE
Suppress Dialyzer errors (hopefully correctly)

### DIFF
--- a/lib/ok.ex
+++ b/lib/ok.ex
@@ -509,7 +509,7 @@ defmodule OK do
   defp expand_bindings([{:<-, env, [left, right]} | rest], yield_block, exception_clauses) do
     line = Keyword.get(env, :line)
 
-    quote line: line do
+    quote line: line, generated: true do
       case unquote(right) do
         {:ok, unquote(left)} ->
           unquote(expand_bindings(rest, yield_block, exception_clauses))


### PR DESCRIPTION
Using `OK.for` produces a lot of these kinds of errors on lines that use the `<-` operator:

```
[ElixirLS Dialyzer] The variable _@6 can never match since previous clauses completely covered the type {'error',_} | {'ok',_}
```

According to the docs: 
> `:generated` - marks the given chunk as generated so it does not emit warnings. Currently it only works on special forms (for example, you can annotate a case but not an if).

I think adding this flag suppresses these particular errors. After trying to make deliberate dialyzer errors within an `OK.for` block, I see that they are still getting picked up by dialyzer so I think adding this flag is safe.