### PR TITLE
[WIP] Refactor `OK.with` to fix dialyzer issues

### DIFF
--- a/lib/ok.ex
+++ b/lib/ok.ex
@@ -309,10 +309,10 @@ defmodule OK do
     block_lines = with_do_lines(lines)
     else_lines = Enum.map(exceptions, &with_else_expr/1)
 
-    # catchall_clause = {:->, [], [[{:OK, [], nil}], {:OK, [], nil}]}
+    catchall_clause = {:->, [], [[{:OKVAR, [], nil}], {:OKVAR, [], nil}]}
     do_line_index = length(block_lines) - 1
     block_lines = List.update_at(block_lines, do_line_index, fn do_line ->
-      List.insert_at(do_line, 1, {:else, else_lines})
+      List.insert_at(do_line, 1, {:else, else_lines ++ [catchall_clause]})
     end)
 
     with_return_clause({:with, [], block_lines})

--- a/lib/ok.ex
+++ b/lib/ok.ex
@@ -602,39 +602,6 @@ defmodule OK do
     end
   end
 
-  defp bind_match([]) do
-    quote do: nil
-  end
-
-  defp bind_match([{:<-, env, [left, right]} | rest]) do
-    line = Keyword.get(env, :line)
-    lhs_string = Macro.to_string(left)
-    rhs_string = Macro.to_string(right)
-    tmp = quote do: tmp
-
-    quote line: line do
-      case unquote(tmp) = unquote(right) do
-        {:ok, unquote(left)} ->
-          unquote(bind_match(rest) || tmp)
-
-        result = {:error, _} ->
-          result
-
-        return ->
-          raise %OK.BindError{return: return, lhs: unquote(lhs_string), rhs: unquote(rhs_string)}
-      end
-    end
-  end
-
-  defp bind_match([normal | rest]) do
-    tmp = quote do: tmp
-
-    quote do
-      unquote(tmp) = unquote(normal)
-      unquote(bind_match(rest) || tmp)
-    end
-  end
-
   @doc """
   Transform every element of a list with a mapping function.
   The mapping function must return a result tuple.

--- a/lib/ok.ex
+++ b/lib/ok.ex
@@ -309,10 +309,10 @@ defmodule OK do
     block_lines = with_do_lines(lines)
     else_lines = Enum.map(exceptions, &with_else_expr/1)
 
-    catchall_clause = {:->, [], [[{:OKVAR, [], nil}], {:OKVAR, [], nil}]}
+    default_clause = {:->, [], [[{:OKVAR, [], nil}], {:OKVAR, [], nil}]}
     do_line_index = length(block_lines) - 1
     block_lines = List.update_at(block_lines, do_line_index, fn do_line ->
-      List.insert_at(do_line, 1, {:else, else_lines ++ [catchall_clause]})
+      List.insert_at(do_line, 1, {:else, else_lines ++ [default_clause]})
     end)
 
     with_return_clause({:with, [], block_lines})
@@ -420,7 +420,9 @@ defmodule OK do
   Any line using this operator that trys to match on an error tuple will result in early return.
 
   If all bindings can be made, i.e. all functions returned `{:ok, value}`,
-  ... any bind fails then the else block will be tried.
+  then the after block is executed to return the final value.
+
+  If any bind fails then the rescue block will be tried.
 
   *Note: return value from after will be returned unwrapped*
 


### PR DESCRIPTION
This PR is an attempt to do a few things:

1) learn more about the library and macros (this is honestly the ultimate goal for me, this library is awesome and if none of these changes make it in, no big deal)
2) propose that we keep `OK.with` (I like it better than the others as it feels more in line with the existing `with` special form and doesn't require an `after` block, but that just may be me)
3) fix the dialyzer issues I was having using `OK.with`
4) use those fixes as a potential template strategy to fix similar dialyzer errors I found with the other macros in this library, issues like:
```
[ElixirLS Dialyzer] The pattern {'error', _@4} can never match the type {'ok',{non_neg_integer(),#{binary()=>non_neg_integer()}}}
[ElixirLS Dialyzer] The variable _@6 can never match since previous clauses completely covered the type {'ok',{non_neg_integer(),#{binary()=>non_neg_integer()}}}
```

My general approach was map the API and functionality of `OK.with` to any existing special forms as simply as possible - which in this case is the `with` special form. All special clauses are transformed to match against the `ok` tuple, and if any fails to match, defer to a clause in the `else` block.

Implementation details:
  - if the expression contains `<-`, replace the expression with one that matches against the right hand side, continuing with a tagged tuple if it returns a tagged tuple, otherwise throwing a `BindError`
  - if the final expression is along the lines of `_ <- ...` replace the `_` with a stubbed variable name `:OKVAR` and have the following `do` block return `{:ok, {:OKVAR, env, nil}}`
  - if the final expression uses the `=` match operator, keep it and add a `do` block that returns `{:ok, <matched_variable>}`
  - to preserve existing behaviour (namely, the test titled `"will fail to match if the return value of exceptional block is not a result"`), a default clause is added to the end of the list of else clauses.
  - the entire generated `with` block is wrapped in a case clause to guarantee that all values returned are a tagged tuple, and if not, a `CaseClauseError` is thrown.

Remaining Tasks/Assumptions to verify:
- [x] actually make sure that this reduces the OK dialyzer errors :)
- [x] `_` cannot be read from, so I replace it with `:OKVAR` assuming that no one would name a variable `OKVAR` before this line and use it after. Probably a bad assumption, what's a better alternative?
- [ ] not sure if I'm using the quote's metadata properly, or if I'm mangling it
- [ ] is the default clause bad practice? The original `with` requires an explicit default else case...