### PR TITLE
Add remaining type specs

### DIFF
--- a/lib/ok.ex
+++ b/lib/ok.ex
@@ -42,9 +42,9 @@ defmodule OK do
       iex> OK.bind({:error, :some_reason}, fn (x) -> {:ok, 2 * x} end)
       {:error, :some_reason}
   """
-  # @spec bind({:ok, a} | {:error, reason}, function(a) :: {:ok, b} | {:error, reason}) ::
-  #         {:ok, b} | {:error, reason}
-  #       when a: any, b: any, reason: term
+  @spec bind({:ok, a} | {:error, reason}, function(a) :: {:ok, b} | {:error, reason}) ::
+          {:ok, b} | {:error, reason}
+        when a: any, b: any, reason: term
   # NOTE return value of function is not checked to be a result tuple.
   # errors are informative enough when piped to something else expecting result tuple.
   # Also dialyzer will catch in anonymous function with incorrect typespec is given.

--- a/lib/ok.ex
+++ b/lib/ok.ex
@@ -24,8 +24,8 @@ defmodule OK do
       iex> OK.map({:error, :some_reason}, fn (x) -> 2 * x end)
       {:error, :some_reason}
   """
-  @spec map({:ok, a}, function(a) :: b) :: {:ok, b} when a: any, b: any
-  @spec map({:error, reason}, function(any) :: any) :: {:error, reason} when reason: any
+  @spec map({:ok, a}, (a -> b)) :: {:ok, b} when a: any, b: any
+  @spec map({:error, reason}, (any -> any)) :: {:error, reason} when reason: any
   def map({:ok, value}, func) when is_function(func, 1), do: {:ok, func.(value)}
   def map({:error, reason}, _func), do: {:error, reason}
 
@@ -42,9 +42,9 @@ defmodule OK do
       iex> OK.bind({:error, :some_reason}, fn (x) -> {:ok, 2 * x} end)
       {:error, :some_reason}
   """
-  @spec bind({:ok, a} | {:error, reason}, function(a) :: {:ok, b} | {:error, reason}) ::
+  @spec bind({:ok, a} | {:error, reason}, (a -> {:ok, b} | {:error, reason})) ::
           {:ok, b} | {:error, reason}
-        when a: any, b: any, reason: term
+        when a: any, b: any, reason: any
   # NOTE return value of function is not checked to be a result tuple.
   # errors are informative enough when piped to something else expecting result tuple.
   # Also dialyzer will catch in anonymous function with incorrect typespec is given.
@@ -95,6 +95,7 @@ defmodule OK do
       iex> OK.required(Map.get(%{}, :port), :port_number_required)
       {:error, :port_number_required}
   """
+  @spec required(any, any) :: {:ok, any} | {:error, any}
   def required(value, reason \\ :value_required)
   def required(nil, reason), do: {:error, reason}
   def required(value, _reason), do: {:ok, value}
@@ -597,10 +598,12 @@ defmodule OK do
       {:error, :zero_division}
   """
 
-  def map_all(list, fun) do
+  @spec map_all([a], (a -> {:ok, b} | {:error, reason})) :: {:ok, [b]} | {:error, reason}
+        when a: any, b: any, reason: any
+  def map_all(list, func) when is_function(func, 1) do
     result =
       Enum.reduce_while(list, [], fn value, acc ->
-        case fun.(value) do
+        case func.(value) do
           {:ok, value} ->
             {:cont, [value | acc]}
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule OK.Mixfile do
   def project do
     [
       app: :ok,
-      version: "1.11.1",
+      version: "1.11.2",
       elixir: "~> 1.1",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,


### PR DESCRIPTION
To test checkout this branch and run

```
MIX_ENV=test mix dialyzer
```
*integration file is only compile in the test environment.*

Dialyzer produces the following warnings
```
test/integration.ex:5:no_return
Function run/0 has no local return.
________________________________________________________________________________
Please file a bug in https://github.com/jeremyjh/dialyxir/issues with this message.

Failed to parse warning:
[{:"(", 1}, {:"{", 1}, {:atom_full, 1, '\'ok\''}, {:",", 1}, {:atom_part, 1, 'a'}, {:"}", 1}, {:|, 1}, {:"{", 1}, {:atom_full, 1, '\'error\''}, {:",", 1}, {:atom_part, 1, 'r'}, {:atom_part, 1, 'e'}, {:atom_part, 1, 'a'}, {:atom_part, 1, 's'}, {:atom_part, 1, 'o'}, {:atom_part, 1, 'n'}, {:"}", 1}, {:",", 1}, {:atom_part, 1, 'f'}, {:atom_part, 1, 'u'}, {:atom_part, 1, 'n'}, {:atom_part, 1, 'c'}, {:atom_part, 1, 't'}, {:atom_part, 1, 'i'}, {:atom_part, 1, 'o'}, {:atom_part, 1, 'n'}, {:"(", 1}, {:atom_part, 1, 'a'}, {:")", 1}, {:::, 1}, {:"{", 1}, {:atom_full, 1, '\'ok\''}, {:",", 1}, {:atom_part, 1, 'b'}, {:"}", 1}, {:|, 1}, {:"{", 1}, {:atom_full, 1, '\'error\''}, {:",", 1}, {:atom_part, 1, 'r'}, {:atom_part, 1, 'e'}, {:atom_part, 1, 'a'}, {:atom_part, 1, 's'}, {:atom_part, 1, 'o'}, {:atom_part, 1, 'n'}, {:"}", 1}, {:")", 1}, {:->, 1}, {:"{", ...}, {...}, ...]


Legacy warning:
test/integration.ex:13: The call 'Elixir.OK':bind({'error','zero_division'} | {'ok',float()},fun((_) -> {'error','zero_division'} | {'ok',float()})) breaks the contract ({'ok',a} | {'error',reason},function(a)::{'ok',b} | {'error',reason}) -> {'ok',b} | {'error',reason} when a :: any(), b :: any(), reason :: term()
________________________________________________________________________________
test/integration.ex:41:unused_fun
Function fetch_key/2 will never be called.
________________________________________________________________________________
```