### PR TITLE
Add a filter/3 function

### DIFF
--- a/lib/ok.ex
+++ b/lib/ok.ex
@@ -84,6 +84,38 @@ defmodule OK do
   end
 
   @doc """
+  Takes a result tuple, a predicate function, and an optional error reason.
+  If the result tuple is tagged as a success then its value will be passed to the predicate function.
+  If the predicate returns `true`, then the result tuple stay the same.
+  If the predicate returns `false, then the result tuple becomes `{:error, reason}`.
+  If the tag is failure then the predicate function is skipped.
+
+  ## Examples
+
+      iex> OK.filter({:ok, 2}, fn (x) -> x == 2 end)
+      {:ok, 2}
+
+      iex> OK.filter({:ok, 2}, fn (x) -> x == 3 end, :bad_value)
+      {:error, :bad_value}
+
+      iex> OK.filter({:error, :some_reason}, fn (x) -> x == 4 end)
+      {:error, :some_reason}
+  """
+  @spec filter({:ok, a} | {:error, reason}, (a -> boolean), test_failure_reason) ::
+          {:ok, a} | {:error, test_failure_reason} | {:error, reason}
+        when a: any, reason: any, test_failure_reason: any
+  def filter(result_tuple, func, reason \\ :failed_predicate)
+
+  def filter({:ok, value}, func, reason) when is_function(func, 1) do
+    case func.(value) do
+      true -> {:ok, value}
+      false -> {:error, reason}
+    end
+  end
+
+  def filter({:error, reason}, _func, _reason), do: {:error, reason}
+
+  @doc """
   Wraps a value as a successful result tuple.
 
   ## Examples

--- a/lib/ok.ex
+++ b/lib/ok.ex
@@ -92,29 +92,29 @@ defmodule OK do
 
   ## Examples
 
-      iex> OK.filter({:ok, 2}, fn (x) -> x == 2 end, :bad_value)
+      iex> OK.check({:ok, 2}, fn (x) -> x == 2 end, :bad_value)
       {:ok, 2}
 
-      iex> OK.filter({:ok, 2}, fn (x) -> x == 3 end, :bad_value)
+      iex> OK.check({:ok, 2}, fn (x) -> x == 3 end, :bad_value)
       {:error, :bad_value}
 
-      iex> OK.filter({:error, :some_reason}, fn (x) -> x == 4 end, :bad_value)
+      iex> OK.check({:error, :some_reason}, fn (x) -> x == 4 end, :bad_value)
       {:error, :some_reason}
   """
-  @spec filter({:ok, a}, (a -> boolean), test_failure_reason) ::
+  @spec check({:ok, a}, (a -> boolean), test_failure_reason) ::
           {:ok, a} | {:error, test_failure_reason}
         when a: any, test_failure_reason: any
-  @spec filter({:error, reason}, (a -> boolean), test_failure_reason) :: {:error, reason}
+  @spec check({:error, reason}, (a -> boolean), test_failure_reason) :: {:error, reason}
         when a: any, reason: any, test_failure_reason: any
 
-  def filter({:ok, value}, func, reason) when is_function(func, 1) do
+  def check({:ok, value}, func, reason) when is_function(func, 1) do
     case func.(value) do
       true -> {:ok, value}
       false -> {:error, reason}
     end
   end
 
-  def filter({:error, reason}, _func, _reason), do: {:error, reason}
+  def check({:error, reason}, _func, _reason), do: {:error, reason}
 
   @doc """
   Wraps a value as a successful result tuple.

--- a/lib/ok.ex
+++ b/lib/ok.ex
@@ -92,19 +92,20 @@ defmodule OK do
 
   ## Examples
 
-      iex> OK.filter({:ok, 2}, fn (x) -> x == 2 end)
+      iex> OK.filter({:ok, 2}, fn (x) -> x == 2 end, :bad_value)
       {:ok, 2}
 
       iex> OK.filter({:ok, 2}, fn (x) -> x == 3 end, :bad_value)
       {:error, :bad_value}
 
-      iex> OK.filter({:error, :some_reason}, fn (x) -> x == 4 end)
+      iex> OK.filter({:error, :some_reason}, fn (x) -> x == 4 end, :bad_value)
       {:error, :some_reason}
   """
-  @spec filter({:ok, a} | {:error, reason}, (a -> boolean), test_failure_reason) ::
-          {:ok, a} | {:error, test_failure_reason} | {:error, reason}
+  @spec filter({:ok, a}, (a -> boolean), test_failure_reason) ::
+          {:ok, a} | {:error, test_failure_reason}
+        when a: any, test_failure_reason: any
+  @spec filter({:error, reason}, (a -> boolean), test_failure_reason) :: {:error, reason}
         when a: any, reason: any, test_failure_reason: any
-  def filter(result_tuple, func, reason \\ :failed_predicate)
 
   def filter({:ok, value}, func, reason) when is_function(func, 1) do
     case func.(value) do

--- a/test/ok_test.exs
+++ b/test/ok_test.exs
@@ -46,6 +46,21 @@ defmodule OKTest do
     end
   end
 
+  test "filter returns {:ok, value} when the test is true" do
+    result = OK.filter({:ok, "test"}, fn value -> value == "test" end, :bad_value)
+    assert {:ok, "test"} = result
+  end
+
+  test "filter returns {:error, reason} when the test is false" do
+    result = OK.filter({:ok, "test"}, fn value -> value == "other_string" end, :bad_value)
+    assert {:error, :bad_value} = result
+  end
+
+  test "filter does nothing when the original result tuple is tagged as :error" do
+    result = OK.filter({:error, :some_reason}, fn value -> value == "test" end)
+    assert {:error, :some_reason} = result
+  end
+
   # These are all used in doc tests
   def double(a) do
     {:ok, 2 * a}

--- a/test/ok_test.exs
+++ b/test/ok_test.exs
@@ -46,21 +46,6 @@ defmodule OKTest do
     end
   end
 
-  test "filter returns {:ok, value} when the test is true" do
-    result = OK.filter({:ok, "test"}, fn value -> value == "test" end, :bad_value)
-    assert {:ok, "test"} = result
-  end
-
-  test "filter returns {:error, reason} when the test is false" do
-    result = OK.filter({:ok, "test"}, fn value -> value == "other_string" end, :bad_value)
-    assert {:error, :bad_value} = result
-  end
-
-  test "filter does nothing when the original result tuple is tagged as :error" do
-    result = OK.filter({:error, :some_reason}, fn value -> value == "test" end)
-    assert {:error, :some_reason} = result
-  end
-
   # These are all used in doc tests
   def double(a) do
     {:ok, 2 * a}


### PR DESCRIPTION
Hi !

At first, thanks for you work. As a new Elixir developer and a Rust lover, I was writing my own result management library, before I find your one.

I'd like to suggest a new `filter/3` function, which tests a `:ok` tagged tuple with a predicate function and an optional error reason, and turns it into `{:error, reason}` when the test fails.