### PR TITLE
Fix doc error for `is_success` guard

### DIFF
--- a/lib/ok.ex
+++ b/lib/ok.ex
@@ -164,8 +164,8 @@ defmodule OK do
 
   @doc guard: true
   @doc """
-  Checks if a result tuple is tagged as `:error`, and returns `true` if so.
-  If the tuple is tagged as `:ok`, returns `false`.
+  Checks if a result tuple is tagged as `:ok`, and returns `true` if so.
+  If the tuple is tagged as `:error`, returns `false`.
 
   Allowed in guards.
 


### PR DESCRIPTION
Quick fix for a minor error (probably copy-paste related) in the `is_sucess` guard's documentation.